### PR TITLE
Eval: Use `path` instead of `fsPath`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-jsonnet",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-jsonnet",
-			"version": "0.3.1",
+			"version": "0.3.2",
 			"license": "Apache License Version 2.0",
 			"dependencies": {
 				"@types/vscode": "^1.69.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -224,9 +224,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.70.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
-			"integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA=="
+			"version": "1.72.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+			"integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "4.33.0",
@@ -880,9 +880,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1457,9 +1457,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -1675,9 +1675,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -1792,9 +1792,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true
 		},
 		"@babel/highlight": {
@@ -1947,9 +1947,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.70.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
-			"integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA=="
+			"version": "1.72.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+			"integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw=="
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.33.0",
@@ -2401,9 +2401,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -2820,9 +2820,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -2979,9 +2979,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Full code support (formatting, highlighting, navigation, etc) for Jsonnet",
 	"license": "Apache License Version 2.0",
 	"publisher": "Grafana",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/grafana/vscode-jsonnet"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 			const editor = window.activeTextEditor;
 			const params: ExecuteCommandParams = {
 				command: `jsonnet.evalItem`,
-				arguments: [editor.document.uri.fsPath, editor.selection.active],
+				arguments: [editor.document.uri.path, editor.selection.active],
 			};
 			evalAndDisplay(params, false);
 		}),
@@ -54,7 +54,7 @@ function evalFileFunc(yaml: boolean) {
 		const editor = window.activeTextEditor;
 		const params: ExecuteCommandParams = {
 			command: `jsonnet.evalFile`,
-			arguments: [editor.document.uri.fsPath],
+			arguments: [editor.document.uri.path],
 		};
 		evalAndDisplay(params, yaml);
 	};
@@ -67,7 +67,7 @@ function evalExpressionFunc(yaml: boolean) {
 			if (expr) {
 				const params: ExecuteCommandParams = {
 					command: `jsonnet.evalExpression`,
-					arguments: [editor.document.uri.fsPath, expr],
+					arguments: [editor.document.uri.path, expr],
 				};
 				evalAndDisplay(params, yaml);
 			} else {


### PR DESCRIPTION
Tentative fix for https://github.com/grafana/vscode-jsonnet/issues/19 `fsPath` shows an OS-specific path (with backslashes in Windows). `path` is a URI that's supposed to be globally valid