### PR TITLE
fix: correctly highlight text verbatim

### DIFF
--- a/language/jsonnet.tmLanguage.json
+++ b/language/jsonnet.tmLanguage.json
@@ -132,7 +132,7 @@
                     "include": "#double-quoted-strings"
                 },
                 {
-                    "include": "#triple-quoted-strings"
+                    "include": "#block-text-verbatim"
                 },
                 {
                     "include": "#builtin-functions"
@@ -232,12 +232,18 @@
                 }
             ]
         },
-        "triple-quoted-strings": {
+        "block-text-verbatim": {
             "patterns": [
                 {
-                    "begin": "\\|\\|\\|",
+                    "begin": "(?:\\|\\|\\|)(?:\\s*$)",
                     "end": "\\|\\|\\|",
-                    "name": "string.quoted.triple.jsonnet"
+                    "patterns": [
+                        {
+                            "begin": "^([ \t]+)(?! |\t|\\|)",
+                            "end": "^(?!\\1|\\s*$)",
+                            "name": "string.unquoted.verbatim.jsonnet"
+                        }
+                    ]
                 }
             ]
         }

--- a/language/jsonnet.tmLanguage.json
+++ b/language/jsonnet.tmLanguage.json
@@ -239,7 +239,7 @@
                     "end": "\\|\\|\\|",
                     "patterns": [
                         {
-                            "begin": "^([ \t]+)(?! |\t|\\|)",
+                            "begin": "^([ \t]+)(?! |\t|\\|(?=\\|))",
                             "end": "^(?!\\1|\\s*$)",
                             "name": "string.unquoted.verbatim.jsonnet"
                         }

--- a/language/jsonnet.tmLanguage.json
+++ b/language/jsonnet.tmLanguage.json
@@ -236,12 +236,13 @@
             "patterns": [
                 {
                     "begin": "(?:\\|\\|\\|)(?:\\s*$)",
-                    "end": "\\|\\|\\|",
+                    "end": "^\\s*\\|\\|\\|",
+                    "name": "keyword.other.jsonnet",
                     "patterns": [
                         {
-                            "begin": "^([ \t]+)(?! |\t|\\|(?=\\|))",
+                            "begin": "^([ \t]+)(?! |\t)",
                             "end": "^(?!\\1|\\s*$)",
-                            "name": "string.unquoted.verbatim.jsonnet"
+                            "name": "string.unquoted.block.jsonnet"
                         }
                     ]
                 }


### PR DESCRIPTION
I have updated the language grammar to correctly highlight `|||` text block.

> Text block, beginning with |||, followed by optional whitespace and a new-line. The next non-empty line must be prefixed with some non-zero length whitespace W. The block ends at the first subsequent line that is non-empty and does not begin with W, and it is an error if this line does not contain some optional whitespace followed by |||. The content of the string is the concatenation of all the lines between the two |||, which either begin with W (in which case that prefix is stripped) or they are empty lines (in which case they remain as empty lines). The line ending style in the file is preserved in the string. This form cannot be used in import statements.

https://jsonnet.org/ref/spec.html

I looked into yaml definition and made couple changes to it.

https://github.com/microsoft/vscode/blob/eef30e7165e19b33daa1e15e92fa34ff4a5df0d3/extensions/yaml/syntaxes/yaml.tmLanguage.json#L120-L155

Before:
![image](https://github.com/grafana/vscode-jsonnet/assets/1218946/b0caef1d-24fd-4e96-a448-2429b17c5a0c)

After:
![image](https://github.com/grafana/vscode-jsonnet/assets/1218946/11003719-5e7c-4093-8765-d1073df5c6e5)
![image](https://github.com/grafana/vscode-jsonnet/assets/1218946/a43d4dc6-954d-445d-b8fb-a53b9690becd)

