### PR TITLE
feat: add a button to evaluate jsonnet files on titlebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
 					"group": "navigation",
 					"when": "false"
 				}
+			],
+			"editor/title": [
+				{
+					"command": "jsonnet.evalFile",
+					"alt": "jsonnet.evalFileYaml",
+					"group": "navigation",
+					"when": "resourceLangId == jsonnet"
+				}
 			]
 		},
 		"commands": [
@@ -47,12 +55,14 @@
 			{
 				"command": "jsonnet.evalFile",
 				"title": "Jsonnet: Evaluate File",
-				"enablement": "resourceLangId == jsonnet"
+				"enablement": "resourceLangId == jsonnet",
+				"icon": "$(open-preview)"
 			},
 			{
 				"command": "jsonnet.evalFileYaml",
 				"title": "Jsonnet: Evaluate File (YAML)",
-				"enablement": "resourceLangId == jsonnet"
+				"enablement": "resourceLangId == jsonnet",
+				"icon": "$(open-preview)"
 			},
 			{
 				"command": "jsonnet.evalExpression",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { commands, window, workspace, ExtensionContext, Uri, OutputChannel, TextEditor } from 'vscode';
+import { commands, window, workspace, ExtensionContext, Uri, OutputChannel, TextEditor, ViewColumn } from 'vscode';
 import * as fs from 'fs';
 import * as os from 'os';
 import { stringify as stringifyYaml } from 'yaml';
@@ -95,7 +95,10 @@ function evalAndDisplay(params: ExecuteCommandParams, yaml: boolean): void {
 				uri = Uri.file(tempYamlFile);
 				fs.writeFileSync(tempYamlFile, yamlString);
 			}
-			window.showTextDocument(uri, { preview: true });
+			window.showTextDocument(uri, {
+				preview: true,
+				viewColumn: ViewColumn.Beside
+			});
 		})
 		.catch(err => {
 			window.showErrorMessage(err.message);


### PR DESCRIPTION
1. add a button to evaluate jsonnet files on titlebar (click to compile to json, alt+click to compile to yaml)

<img width="660" alt="image" src="https://github.com/grafana/vscode-jsonnet/assets/15522311/66ad2e37-0e45-4ad1-95f5-2d85f2085f65">


2. preview evaluation result in splited editor

preview video:

https://github.com/grafana/vscode-jsonnet/assets/15522311/cc7e782e-4b49-48f7-b135-d0882ab2277a
