### PR TITLE
feat: add debugger support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Full code support (formatting, highlighting, navigation, debugging etc) for Jsonnet",
 	"license": "Apache License Version 2.0",
 	"publisher": "Grafana",
-	"version": "0.6.0-test",
+	"version": "0.6.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/grafana/vscode-jsonnet"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Full code support (formatting, highlighting, navigation, debugging etc) for Jsonnet",
 	"license": "Apache License Version 2.0",
 	"publisher": "Grafana",
-	"version": "0.5.1",
+	"version": "0.6.0-test",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/grafana/vscode-jsonnet"
@@ -140,8 +140,11 @@
 								"description": "jsonnet script to run"
 							},
 							"jpaths": {
-								"type": "string[]",
-								"description": "jsonnet search paths"
+								"type": "array",
+								"description": "jsonnet search paths",
+								"items": {
+									"type": "string"
+								}
 							}
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-jsonnet",
 	"icon": "icon.png",
 	"displayName": "Jsonnet Language Server",
-	"description": "Full code support (formatting, highlighting, navigation, etc) for Jsonnet",
+	"description": "Full code support (formatting, highlighting, navigation, debugging etc) for Jsonnet",
 	"license": "Apache License Version 2.0",
 	"publisher": "Grafana",
 	"version": "0.5.1",
@@ -16,13 +16,15 @@
 	"categories": [
 		"Programming Languages",
 		"Linters",
-		"Formatters"
+		"Formatters",
+		"Debuggers"
 	],
 	"keywords": [
 		"jsonnet",
 		"grafana",
 		"lsp",
-		"language"
+		"language",
+		"debugger"
 	],
 	"activationEvents": [
 		"onLanguage:jsonnet"
@@ -43,6 +45,13 @@
 					"alt": "jsonnet.evalFileYaml",
 					"group": "navigation",
 					"when": "resourceLangId == jsonnet"
+				}
+			],
+			"editor/title/run": [
+				{
+					"command": "jsonnet.debugEditorContents",
+					"when": "resourceLangId == jsonnet",
+					"group": "navigation@1"
 				}
 			]
 		},
@@ -77,6 +86,13 @@
 			{
 				"command": "jsonnet.restartLanguageServer",
 				"title": "Jsonnet: Restart Language Server"
+			},
+			{
+				"command": "jsonnet.debugEditorContents",
+				"title": "Jsonnet: Debug File",
+				"category": "Jsonnet",
+				"enablement": "!inDebugMode",
+				"icon": "$(debug-alt)"
 			}
 		],
 		"languages": [
@@ -98,6 +114,51 @@
 				"language": "jsonnet",
 				"scopeName": "source.jsonnet",
 				"path": "./language/jsonnet.tmLanguage.json"
+			}
+		],
+		"breakpoints": [
+			{
+				"language": "jsonnet"
+			}
+		],
+		"debuggers": [
+			{
+				"type": "jsonnet",
+				"languages": [
+					"jsonnet"
+				],
+				"label": "Jsonnet Debugger",
+				"configurationAttributes": {
+					"launch": {
+						"required": [
+							"program",
+							"jpaths"
+						],
+						"properties": {
+							"program": {
+								"type": "string",
+								"description": "jsonnet script to run"
+							},
+							"jpaths": {
+								"type": "string[]",
+								"description": "jsonnet search paths"
+							}
+						}
+					}
+				},
+				"initialConfigurations": [],
+				"configurationSnippets": [
+					{
+						"label": "Jsonnet: Debug current file",
+						"description": "A new configuration for debugging a Jsonnet file.",
+						"body": {
+							"type": "jsonnet",
+							"request": "launch",
+							"name": "Debug current JSONNET file",
+							"program": "^\"\\${file}\""
+						}
+					}
+				]
 			}
 		],
 		"configuration": {
@@ -221,6 +282,21 @@
 					],
 					"default": "info",
 					"description": "Log level for the language server"
+				},
+				"jsonnet.debugger.releaseRepository": {
+					"type": "string",
+					"default": "grafana/jsonnet-debugger",
+					"description": "Github repository to download the debugger server from"
+				},
+				"jsonnet.debugger.enableAutoUpdate": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true
+				},
+				"jsonnet.debugger.pathToBinary": {
+					"scope": "resource",
+					"type": "string",
+					"description": "Path to debugger"
 				}
 			}
 		}

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+
+export class JsonnetDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+  context: vscode.ExtensionContext;
+  binPath: string;
+
+  constructor(context: vscode.ExtensionContext, binPath: string) {
+    this.context = context;
+    this.binPath = binPath;
+  }
+
+  createDebugAdapterDescriptor(
+    session: vscode.DebugSession,
+    executable: vscode.DebugAdapterExecutable | undefined
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    return new vscode.DebugAdapterExecutable(this.binPath, ['-d', '-s']);
+  }
+}


### PR DESCRIPTION
This implements support for debugging jsonnet files based on https://github.com/google/go-jsonnet/pull/739.

The installation works the same way as the language server. By default, the following repository is used: https://github.com/grafana/jsonnet-debugger

The current checked in files were formatted inconsistently, that's why there's such a large diff.

Summarized Changes:
- Add parameters to install function
- register debug provider
- register dynamic debug configurations