### PR TITLE
chore: apply consistent styling & editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 120

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "jsxSingleQuote": false,
+  "singleQuote": true
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,13 +5,13 @@ import * as os from 'os';
 import { stringify as stringifyYaml } from 'yaml';
 
 import {
-	DidChangeConfigurationNotification,
-	Executable,
-	ExecuteCommandParams,
-	ExecuteCommandRequest,
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
+  DidChangeConfigurationNotification,
+  Executable,
+  ExecuteCommandParams,
+  ExecuteCommandRequest,
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
 } from 'vscode-languageclient/node';
 import { install } from './install';
 
@@ -20,158 +20,154 @@ let client: LanguageClient;
 let channel: OutputChannel;
 
 export async function activate(context: ExtensionContext): Promise<void> {
-	channel = window.createOutputChannel('Jsonnet');
-	extensionContext = context;
+  channel = window.createOutputChannel('Jsonnet');
+  extensionContext = context;
 
-	await startClient();
-	await didChangeConfigHandler();
+  await startClient();
+  await didChangeConfigHandler();
 
-	context.subscriptions.push(
-		workspace.onDidChangeConfiguration(didChangeConfigHandler),
-		commands.registerCommand('jsonnet.restartLanguageServer', async function (): Promise<void> {
-			await client.stop();
-			client.outputChannel.dispose();
-			await startClient();
-			await didChangeConfigHandler();
-		}),
-		commands.registerCommand('jsonnet.evalItem', async () => {
-			// Not enabled for now, because the language server doesn't support it.
-			const editor = window.activeTextEditor;
-			const params: ExecuteCommandParams = {
-				command: `jsonnet.evalItem`,
-				arguments: [evalFilePath(editor), editor.selection.active],
-			};
-			evalAndDisplay(params, false);
-		}),
-		commands.registerCommand('jsonnet.evalFile', evalFileFunc(false)),
-		commands.registerCommand('jsonnet.evalFileYaml', evalFileFunc(true)),
-		commands.registerCommand('jsonnet.evalExpression', evalExpressionFunc(false)),
-		commands.registerCommand('jsonnet.evalExpressionYaml', evalExpressionFunc(true))
-	);
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(didChangeConfigHandler),
+    commands.registerCommand('jsonnet.restartLanguageServer', async function (): Promise<void> {
+      await client.stop();
+      client.outputChannel.dispose();
+      await startClient();
+      await didChangeConfigHandler();
+    }),
+    commands.registerCommand('jsonnet.evalItem', async () => {
+      // Not enabled for now, because the language server doesn't support it.
+      const editor = window.activeTextEditor;
+      const params: ExecuteCommandParams = {
+        command: `jsonnet.evalItem`,
+        arguments: [evalFilePath(editor), editor.selection.active],
+      };
+      evalAndDisplay(params, false);
+    }),
+    commands.registerCommand('jsonnet.evalFile', evalFileFunc(false)),
+    commands.registerCommand('jsonnet.evalFileYaml', evalFileFunc(true)),
+    commands.registerCommand('jsonnet.evalExpression', evalExpressionFunc(false)),
+    commands.registerCommand('jsonnet.evalExpressionYaml', evalExpressionFunc(true))
+  );
 }
 
 function evalFileFunc(yaml: boolean) {
-	return async () => {
-		const editor = window.activeTextEditor;
-		const params: ExecuteCommandParams = {
-			command: `jsonnet.evalFile`,
-			arguments: [evalFilePath(editor)],
-		};
-		evalAndDisplay(params, yaml);
-	};
+  return async () => {
+    const editor = window.activeTextEditor;
+    const params: ExecuteCommandParams = {
+      command: `jsonnet.evalFile`,
+      arguments: [evalFilePath(editor)],
+    };
+    evalAndDisplay(params, yaml);
+  };
 }
 
 function evalExpressionFunc(yaml: boolean) {
-	return async () => {
-		const editor = window.activeTextEditor;
-		window.showInputBox({ prompt: 'Expression to evaluate' }).then(async (expr) => {
-			if (expr) {
-				const params: ExecuteCommandParams = {
-					command: `jsonnet.evalExpression`,
-					arguments: [evalFilePath(editor), expr],
-				};
-				evalAndDisplay(params, yaml);
-			} else {
-				window.showErrorMessage('No expression provided');
-			}
-		});
-	};
+  return async () => {
+    const editor = window.activeTextEditor;
+    window.showInputBox({ prompt: 'Expression to evaluate' }).then(async (expr) => {
+      if (expr) {
+        const params: ExecuteCommandParams = {
+          command: `jsonnet.evalExpression`,
+          arguments: [evalFilePath(editor), expr],
+        };
+        evalAndDisplay(params, yaml);
+      } else {
+        window.showErrorMessage('No expression provided');
+      }
+    });
+  };
 }
 
 function evalAndDisplay(params: ExecuteCommandParams, yaml: boolean): void {
-	channel.appendLine(`Sending eval request: ${JSON.stringify(params)}`);
-	client.sendRequest(ExecuteCommandRequest.type, params)
-		.then(result => {
-			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jsonnet-eval"));
-			const tempFile = path.join(tempDir, "result.json");
-			let uri = Uri.file(tempFile);
-			fs.writeFileSync(tempFile, result);
+  channel.appendLine(`Sending eval request: ${JSON.stringify(params)}`);
+  client
+    .sendRequest(ExecuteCommandRequest.type, params)
+    .then((result) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonnet-eval'));
+      const tempFile = path.join(tempDir, 'result.json');
+      let uri = Uri.file(tempFile);
+      fs.writeFileSync(tempFile, result);
 
-			if (yaml) {
-				const file = fs.readFileSync(tempFile, 'utf8');
-				const parsed = JSON.parse(file);
-				const yamlString = stringifyYaml(parsed);
-				const tempYamlFile = path.join(tempDir, "result.yaml");
-				uri = Uri.file(tempYamlFile);
-				fs.writeFileSync(tempYamlFile, yamlString);
-			}
-			window.showTextDocument(uri, {
-				preview: true,
-				viewColumn: ViewColumn.Beside
-			});
-		})
-		.catch(err => {
-			window.showErrorMessage(err.message);
-		});
+      if (yaml) {
+        const file = fs.readFileSync(tempFile, 'utf8');
+        const parsed = JSON.parse(file);
+        const yamlString = stringifyYaml(parsed);
+        const tempYamlFile = path.join(tempDir, 'result.yaml');
+        uri = Uri.file(tempYamlFile);
+        fs.writeFileSync(tempYamlFile, yamlString);
+      }
+      window.showTextDocument(uri, {
+        preview: true,
+        viewColumn: ViewColumn.Beside,
+      });
+    })
+    .catch((err) => {
+      window.showErrorMessage(err.message);
+    });
 }
 
 function evalFilePath(editor: TextEditor): string {
-	return editor.document.uri.fsPath.replace(/\\/g, '/');
+  return editor.document.uri.fsPath.replace(/\\/g, '/');
 }
 
 export function deactivate(): Thenable<void> | undefined {
-	if (!client) {
-		return undefined;
-	}
-	return client.stop();
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
 }
 
 async function startClient(): Promise<void> {
-	const args: string[] = ["--log-level", workspace.getConfiguration('jsonnet').get('languageServer.logLevel')];
-	if (workspace.getConfiguration('jsonnet').get('languageServer.tankaMode') === true) {
-		args.push('--tanka');
-	}
-	if (workspace.getConfiguration('jsonnet').get('languageServer.lint') === true) {
-		args.push('--lint');
-	}
+  const args: string[] = ['--log-level', workspace.getConfiguration('jsonnet').get('languageServer.logLevel')];
+  if (workspace.getConfiguration('jsonnet').get('languageServer.tankaMode') === true) {
+    args.push('--tanka');
+  }
+  if (workspace.getConfiguration('jsonnet').get('languageServer.lint') === true) {
+    args.push('--lint');
+  }
 
-	const binPath = await install(extensionContext, channel);
-	const executable: Executable = {
-		command: binPath,
-		args: args,
-		options: {
-			env: process.env,
-		},
-	};
-	channel.appendLine(`Jsonnet Language Server will start: '${executable.command} ${executable.args.join(' ')}'`);
+  const binPath = await install(extensionContext, channel);
+  const executable: Executable = {
+    command: binPath,
+    args: args,
+    options: {
+      env: process.env,
+    },
+  };
+  channel.appendLine(`Jsonnet Language Server will start: '${executable.command} ${executable.args.join(' ')}'`);
 
-	const serverOptions: ServerOptions = {
-		run: executable,
-		debug: executable,
-	};
+  const serverOptions: ServerOptions = {
+    run: executable,
+    debug: executable,
+  };
 
-	// Options to control the language client
-	const clientOptions: LanguageClientOptions = {
-		// Register the server for jsonnet files
-		documentSelector: [{ scheme: 'file', language: 'jsonnet' }],
-	};
+  // Options to control the language client
+  const clientOptions: LanguageClientOptions = {
+    // Register the server for jsonnet files
+    documentSelector: [{ scheme: 'file', language: 'jsonnet' }],
+  };
 
-	// Create the language client and start the client.
-	client = new LanguageClient(
-		'jsonnetLanguageServer',
-		'Jsonnet Language Server',
-		serverOptions,
-		clientOptions
-	);
+  // Create the language client and start the client.
+  client = new LanguageClient('jsonnetLanguageServer', 'Jsonnet Language Server', serverOptions, clientOptions);
 
-	// Start the client. This will also launch the server
-	client.start();
+  // Start the client. This will also launch the server
+  client.start();
 }
 
 async function didChangeConfigHandler() {
-	const workspaceConfig = workspace.getConfiguration('jsonnet');
-	let jpath: string[] = workspaceConfig.get('languageServer.jpath');
-	jpath = jpath.map(p => path.isAbsolute(p) ? p : path.join(workspace.workspaceFolders[0].uri.fsPath, p));
-	client.sendNotification(DidChangeConfigurationNotification.type, {
-		settings: {
-			log_level: workspaceConfig.get('languageServer.logLevel'),
-			ext_vars: workspaceConfig.get("languageServer.extVars"),
-			ext_code: workspaceConfig.get("languageServer.extCode"),
-			jpath: jpath,
-			resolve_paths_with_tanka: workspaceConfig.get('languageServer.tankaMode'),
-			enable_lint_diagnostics: workspaceConfig.get('languageServer.lint'),
-			enable_eval_diagnostics: workspaceConfig.get('languageServer.eval'),
-			formatting: workspaceConfig.get('languageServer.formatting'),
-		}
-	});
+  const workspaceConfig = workspace.getConfiguration('jsonnet');
+  let jpath: string[] = workspaceConfig.get('languageServer.jpath');
+  jpath = jpath.map((p) => (path.isAbsolute(p) ? p : path.join(workspace.workspaceFolders[0].uri.fsPath, p)));
+  client.sendNotification(DidChangeConfigurationNotification.type, {
+    settings: {
+      log_level: workspaceConfig.get('languageServer.logLevel'),
+      ext_vars: workspaceConfig.get('languageServer.extVars'),
+      ext_code: workspaceConfig.get('languageServer.extCode'),
+      jpath: jpath,
+      resolve_paths_with_tanka: workspaceConfig.get('languageServer.tankaMode'),
+      enable_lint_diagnostics: workspaceConfig.get('languageServer.lint'),
+      enable_eval_diagnostics: workspaceConfig.get('languageServer.eval'),
+      formatting: workspaceConfig.get('languageServer.formatting'),
+    },
+  });
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,197 +1,204 @@
-import { ExtensionContext, OutputChannel, window, workspace } from "vscode";
+import { ExtensionContext, OutputChannel, window, workspace } from 'vscode';
 import * as https from 'https';
 import * as fs from 'fs';
 import { execFileSync } from 'child_process';
 import * as path from 'path';
 
 export async function install(context: ExtensionContext, channel: OutputChannel): Promise<string> {
-    let binPath: string = workspace.getConfiguration('jsonnet').get('languageServer.pathToBinary');
-    const releaseRepository: string = workspace.getConfiguration('jsonnet').get('languageServer.releaseRepository');
+  let binPath: string = workspace.getConfiguration('jsonnet').get('languageServer.pathToBinary');
+  const releaseRepository: string = workspace.getConfiguration('jsonnet').get('languageServer.releaseRepository');
 
-    // If the binPath is undefined, use a default path
-    const isCustomBinPath = (binPath !== undefined && binPath !== null && binPath !== '');
-    if (!isCustomBinPath) {
-        channel.appendLine(`Not using custom binary path. Using default path`);
-        binPath = path.join(context.globalStorageUri.fsPath, 'bin', 'jsonnet-language-server');
-        if (process.platform.toString() === 'win32') {
-            binPath = `${binPath}.exe`;
-        }
-        const binDir = path.dirname(binPath);
-        try {
-            fs.mkdirSync(binDir, { recursive: true });
-        } catch (e) {
-            const msg = `Failed to create directory ${binDir}`;
-            channel.appendLine(msg);
-            channel.appendLine(e);
-            window.showErrorMessage(msg);
-            throw new Error(msg);
-        }
+  // If the binPath is undefined, use a default path
+  const isCustomBinPath = binPath !== undefined && binPath !== null && binPath !== '';
+  if (!isCustomBinPath) {
+    channel.appendLine(`Not using custom binary path. Using default path`);
+    binPath = path.join(context.globalStorageUri.fsPath, 'bin', 'jsonnet-language-server');
+    if (process.platform.toString() === 'win32') {
+      binPath = `${binPath}.exe`;
     }
-    const binPathExists = fs.existsSync(binPath);
-    channel.appendLine(`Binary path is ${binPath} (exists: ${binPathExists})`);
-
-
-    // Without auto-update, the process ends here.
-    const enableAutoUpdate: boolean = workspace.getConfiguration('jsonnet').get('languageServer.enableAutoUpdate');
-    if (!enableAutoUpdate) {
-        if (!binPathExists) {
-            const msg = "The language server binary does not exist, please set either 'jsonnet.languageServer.pathToBinary' or 'jsonnet.languageServer.enableAutoUpdate'";
-            channel.appendLine(msg);
-            window.showErrorMessage(msg);
-            throw new Error(msg);
-        }
-        return binPath;
-    }
-
-
-
-
-    // Check for the latest release in Github
-    const releaseUrl = `https://api.github.com/repos/${releaseRepository}/releases/latest`;
-    channel.appendLine(`Auto-update is enabled. Fetching latest release from ${releaseUrl}`);
-
-    let releaseData: { name?: string } = {};
-    let latestVersion = "";
+    const binDir = path.dirname(binPath);
     try {
-        const body = await githubApiRequest(releaseUrl);
-        releaseData = JSON.parse(body);
-        latestVersion = releaseData.name;
-        if (latestVersion.startsWith("v")) {
-            latestVersion = latestVersion.substring(1);
-        }
+      fs.mkdirSync(binDir, { recursive: true });
     } catch (e) {
-        const msg = `Failed to fetch latest release from ${releaseUrl}`;
-        channel.appendLine(msg);
-        channel.appendLine(e);
-
-        if (!isCustomBinPath) {
-            window.showErrorMessage(msg);
-            throw new Error(msg);
-        }
-
-        window.showWarningMessage(msg + ". Continuing with the current version.");
-        return binPath;
+      const msg = `Failed to create directory ${binDir}`;
+      channel.appendLine(msg);
+      channel.appendLine(e);
+      window.showErrorMessage(msg);
+      throw new Error(msg);
     }
-    channel.appendLine(`Latest release is ${latestVersion}`);
+  }
+  const binPathExists = fs.existsSync(binPath);
+  channel.appendLine(`Binary path is ${binPath} (exists: ${binPathExists})`);
 
-
-    // Check the current version
-    let doUpdate = false;
+  // Without auto-update, the process ends here.
+  const enableAutoUpdate: boolean = workspace.getConfiguration('jsonnet').get('languageServer.enableAutoUpdate');
+  if (!enableAutoUpdate) {
     if (!binPathExists) {
-        // The binary does not exist. Only install if the user says yes.
-        const value = await window.showInformationMessage(`The language server does not seem to be installed. Do you wish to install the latest version?`, "Yes", "No");
-        doUpdate = (value === "Yes");
-    } else {
-        // The binary exists
-        try {
-            // Check the version
-            let currentVersion = "";
-            const result = execFileSync(binPath, ["--version"]);
-            const prefix = "jsonnet-language-server version ";
-            if (result.toString().startsWith(prefix)) {
-                currentVersion = result.toString().substring(prefix.length).trim();
-            } else {
-                throw new Error("Invalid version string");
-            }
-
-            // Compare the versions and prompt the user if they are different
-            channel.appendLine(`Current release is '${currentVersion}'`);
-            if (currentVersion !== latestVersion) {
-                const value = await window.showInformationMessage(`Current version (${currentVersion}) != latest (${latestVersion}). Do you wish to install the latest version?`, "Yes", "No");
-                doUpdate = (value === "Yes");
-            }
-
-        } catch (e) {
-            // The binary is invalid, prompt the user to update
-            const msg = `Failed to get current version from ${binPath}`;
-            channel.appendLine(msg);
-            channel.appendLine(e);
-
-            const value = await window.showWarningMessage(`${msg}. Do you wish to install the latest version?`, "Yes", "No");
-            doUpdate = (value === "Yes");
-        }
+      const msg =
+        "The language server binary does not exist, please set either 'jsonnet.languageServer.pathToBinary' or 'jsonnet.languageServer.enableAutoUpdate'";
+      channel.appendLine(msg);
+      window.showErrorMessage(msg);
+      throw new Error(msg);
     }
-
-    // Update the binary (if specified by the user)
-    if (doUpdate) {
-        channel.appendLine(`Downloading latest release (${latestVersion}) to ${binPath}...`);
-
-        let platform = process.platform.toString();
-        const arch = {
-            "arm": "armv7",
-            "arm64": "arm64",
-            "x64": "amd64",
-        }[process.arch];
-        let suffix = "";
-        if (platform === 'win32') {
-            platform = 'windows';
-            suffix = '.exe';
-        }
-
-        const url = `https://github.com/${releaseRepository}/releases/download/v${latestVersion}/jsonnet-language-server_${latestVersion}_${platform}_${arch}${suffix}`;
-        channel.appendLine(`Downloading ${url}`);
-
-        try {
-            await download(url, binPath);
-            fs.chmodSync(binPath, 0o777);
-        } catch (e) {
-            const msg = `Failed to download ${url} to ${binPath}`;
-            channel.appendLine(msg);
-            channel.appendLine(e);
-            window.showErrorMessage(msg);
-            throw new Error(msg);
-        }
-
-        channel.appendLine(`Successfully downloaded the language server version ${latestVersion}`);
-        window.showInformationMessage(`Successfully installed the language server version ${latestVersion}`);
-    } else {
-        channel.appendLine(`Not updating the language server.`);
-    }
-
     return binPath;
+  }
+
+  // Check for the latest release in Github
+  const releaseUrl = `https://api.github.com/repos/${releaseRepository}/releases/latest`;
+  channel.appendLine(`Auto-update is enabled. Fetching latest release from ${releaseUrl}`);
+
+  let releaseData: { name?: string } = {};
+  let latestVersion = '';
+  try {
+    const body = await githubApiRequest(releaseUrl);
+    releaseData = JSON.parse(body);
+    latestVersion = releaseData.name;
+    if (latestVersion.startsWith('v')) {
+      latestVersion = latestVersion.substring(1);
+    }
+  } catch (e) {
+    const msg = `Failed to fetch latest release from ${releaseUrl}`;
+    channel.appendLine(msg);
+    channel.appendLine(e);
+
+    if (!isCustomBinPath) {
+      window.showErrorMessage(msg);
+      throw new Error(msg);
+    }
+
+    window.showWarningMessage(msg + '. Continuing with the current version.');
+    return binPath;
+  }
+  channel.appendLine(`Latest release is ${latestVersion}`);
+
+  // Check the current version
+  let doUpdate = false;
+  if (!binPathExists) {
+    // The binary does not exist. Only install if the user says yes.
+    const value = await window.showInformationMessage(
+      `The language server does not seem to be installed. Do you wish to install the latest version?`,
+      'Yes',
+      'No'
+    );
+    doUpdate = value === 'Yes';
+  } else {
+    // The binary exists
+    try {
+      // Check the version
+      let currentVersion = '';
+      const result = execFileSync(binPath, ['--version']);
+      const prefix = 'jsonnet-language-server version ';
+      if (result.toString().startsWith(prefix)) {
+        currentVersion = result.toString().substring(prefix.length).trim();
+      } else {
+        throw new Error('Invalid version string');
+      }
+
+      // Compare the versions and prompt the user if they are different
+      channel.appendLine(`Current release is '${currentVersion}'`);
+      if (currentVersion !== latestVersion) {
+        const value = await window.showInformationMessage(
+          `Current version (${currentVersion}) != latest (${latestVersion}). Do you wish to install the latest version?`,
+          'Yes',
+          'No'
+        );
+        doUpdate = value === 'Yes';
+      }
+    } catch (e) {
+      // The binary is invalid, prompt the user to update
+      const msg = `Failed to get current version from ${binPath}`;
+      channel.appendLine(msg);
+      channel.appendLine(e);
+
+      const value = await window.showWarningMessage(`${msg}. Do you wish to install the latest version?`, 'Yes', 'No');
+      doUpdate = value === 'Yes';
+    }
+  }
+
+  // Update the binary (if specified by the user)
+  if (doUpdate) {
+    channel.appendLine(`Downloading latest release (${latestVersion}) to ${binPath}...`);
+
+    let platform = process.platform.toString();
+    const arch = {
+      arm: 'armv7',
+      arm64: 'arm64',
+      x64: 'amd64',
+    }[process.arch];
+    let suffix = '';
+    if (platform === 'win32') {
+      platform = 'windows';
+      suffix = '.exe';
+    }
+
+    const url = `https://github.com/${releaseRepository}/releases/download/v${latestVersion}/jsonnet-language-server_${latestVersion}_${platform}_${arch}${suffix}`;
+    channel.appendLine(`Downloading ${url}`);
+
+    try {
+      await download(url, binPath);
+      fs.chmodSync(binPath, 0o777);
+    } catch (e) {
+      const msg = `Failed to download ${url} to ${binPath}`;
+      channel.appendLine(msg);
+      channel.appendLine(e);
+      window.showErrorMessage(msg);
+      throw new Error(msg);
+    }
+
+    channel.appendLine(`Successfully downloaded the language server version ${latestVersion}`);
+    window.showInformationMessage(`Successfully installed the language server version ${latestVersion}`);
+  } else {
+    channel.appendLine(`Not updating the language server.`);
+  }
+
+  return binPath;
 }
 
 function download(uri, filename) {
-    return new Promise((resolve, reject) => {
-        const onError = function (e) {
-            fs.unlinkSync(filename);
-            reject(e);
-        };
-        https.get(uri, function (response) {
-            if (response.statusCode >= 200 && response.statusCode < 300) {
-                const fileStream = fs.createWriteStream(filename);
-                fileStream.on('error', onError);
-                fileStream.on('close', resolve);
-                response.pipe(fileStream);
-            } else if (response.headers.location) {
-                resolve(download(response.headers.location, filename));
-            } else {
-                reject(new Error(response.statusCode + ' ' + response.statusMessage));
-            }
-        }).on('error', onError);
-    });
+  return new Promise((resolve, reject) => {
+    const onError = function (e) {
+      fs.unlinkSync(filename);
+      reject(e);
+    };
+    https
+      .get(uri, function (response) {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          const fileStream = fs.createWriteStream(filename);
+          fileStream.on('error', onError);
+          fileStream.on('close', resolve);
+          response.pipe(fileStream);
+        } else if (response.headers.location) {
+          resolve(download(response.headers.location, filename));
+        } else {
+          reject(new Error(response.statusCode + ' ' + response.statusMessage));
+        }
+      })
+      .on('error', onError);
+  });
 }
 
 function githubApiRequest(url: string, options: https.RequestOptions = {}, encoding = 'utf8'): Promise<string> {
-    if (options.headers === undefined) {
-        options.headers = {};
-    }
-    options.headers['User-Agent'] = 'vscode-jsonnet';
-    return new Promise((resolve, reject) => {
-        https.request(url, options, res => {
-            if (res.statusCode === 301 || res.statusCode === 302) { // follow redirects
-                return resolve(githubApiRequest(res.headers.location, options, encoding));
-            }
-            if (res.statusCode !== 200) {
-                return reject(res.statusMessage);
-            }
-            let body = '';
-            res.setEncoding(encoding)
-                .on('data', data => body += data)
-                .on('end', () => resolve(body));
-        })
-            .on('error', reject)
-            .end();
-    });
+  if (options.headers === undefined) {
+    options.headers = {};
+  }
+  options.headers['User-Agent'] = 'vscode-jsonnet';
+  return new Promise((resolve, reject) => {
+    https
+      .request(url, options, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          // follow redirects
+          return resolve(githubApiRequest(res.headers.location, options, encoding));
+        }
+        if (res.statusCode !== 200) {
+          return reject(res.statusMessage);
+        }
+        let body = '';
+        res
+          .setEncoding(encoding)
+          .on('data', (data) => (body += data))
+          .on('end', () => resolve(body));
+      })
+      .on('error', reject)
+      .end();
+  });
 }
-


### PR DESCRIPTION
This adds a prettierrc & editorconfig file to keep styling consistent. The rules are taken from the recommended Grafana style found in the plugin SDK.

Will rebase #37 on this once merged.