### PR TITLE
fix:  syntax highlight broken on function calls or return value

### DIFF
--- a/language/jsonnet.tmLanguage.json
+++ b/language/jsonnet.tmLanguage.json
@@ -10,81 +10,6 @@
         }
     ],
     "repository": {
-        "builtin-functions": {
-            "comment": "Functions from: https://jsonnet.org/ref/stdlib.html",
-            "patterns": [
-                {
-                    "comment": "External Variables",
-                    "match": "\\bstd[.]extVar\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Types and Reflection",
-                    "match": "\\bstd[.](thisFile|type|length|get|objectHas|objectFields|objectValues|objectHasAll|objectFieldsAll|objectValuesAll|prune|mapWithKey)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Mathematical Utilities 1",
-                    "match": "\\bstd[.](abs|sign|max|min|pow|exp|log|exponent|mantissa|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Mathematical Utilities 2",
-                    "match": "\\bstd[.]clamp\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Assertions and Debugging",
-                    "match": "\\bstd[.]assertEqual\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "String Manipulation",
-                    "match": "\\bstd[.](toString|codepoint|char|substr|findSubstr|startsWith|endsWith|stripChars|lstripChars|rstripChars|split|splitLimit|strReplace|asciiUpper|asciiLower|stringChars|format|escapeStringBash|escapeStringDollars|escapeStringJson|escapeStringPython)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Parsing 1",
-                    "match": "\\bstd[.]parse(Int|Octal|Hex|Json|Yaml)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Parsing 2",
-                    "match": "\\bstd[.](encodeUTF8|decodeUTF8)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Manifestation",
-                    "match": "\\bstd[.]manifest(Ini|Python|PythonVars|JsonEx|JsonMinified|YamlDoc|YamlStream|XmlJsonml|TomlEx)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Arrays",
-                    "match": "\\bstd[.](makeArray|member|count|find|map|mapWithIndex|filterMap|flatMap|filter|foldl|foldr|range|repeat|slice|join|lines|flattenArrays|reverse|sort|uniq)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Sets",
-                    "match": "\\bstd[.]set(Inter|Union|Diff|Member)?\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Encoding",
-                    "match": "\\bstd[.](base64|base64DecodeBytes|base64Decode|md5)\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "JSON Merge Patch",
-                    "match": "\\bstd[.]mergePatch\\b",
-                    "name": "support.function.jsonnet"
-                },
-                {
-                    "comment": "Debugging",
-                    "match": "\\bstd[.]trace\\b",
-                    "name": "support.function.jsonnet"
-                }
-            ]
-        },
         "comment": {
             "patterns": [
                 {
@@ -135,9 +60,6 @@
                     "include": "#block-text-verbatim"
                 },
                 {
-                    "include": "#builtin-functions"
-                },
-                {
                     "include": "#functions"
                 }
             ]
@@ -145,19 +67,8 @@
         "functions": {
             "patterns": [
                 {
-                    "begin": "\\b([a-zA-Z_][a-z0-9A-Z_]*)\\s*\\(",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "entity.name.function.jsonnet"
-                        }
-                    },
-                    "end": "\\)",
-                    "name": "meta.function",
-                    "patterns": [
-                        {
-                            "include": "#expression"
-                        }
-                    ]
+                    "match": "\\b((?!function)[a-zA-Z_][a-z0-9A-Z_]*)\\s*\\(",
+                    "name": "entity.name.function.jsonnet"
                 }
             ]
         },


### PR DESCRIPTION
fix:
- function keyword not being highlighted as a keyword
- objects passed as a function arguments had broken highlight

changes:
- removed special "treatment" for jsonnet "builtin" functions (std.*)[1]

[1] those functions are not part of the language nor keywords, they are stdlib... usually there is no stdlib highlights on other langs

hopefully the screenshots are clear enough

### Broken 1:
![image](https://github.com/grafana/vscode-jsonnet/assets/820742/806a17f0-1c15-4534-b546-d1cc03ace085)

### Fixed 1:
![image](https://github.com/grafana/vscode-jsonnet/assets/820742/5076e222-7911-42ad-ab9e-0d57cd769ad5)

### Broken 2:
![image](https://github.com/grafana/vscode-jsonnet/assets/820742/c1fc57cc-0cc7-496a-b6aa-0cbfebe1451d)

### Fixed 2:
![image](https://github.com/grafana/vscode-jsonnet/assets/820742/3c1f5f52-314a-4308-b524-01a0198abb80)
