### PR TITLE
feat:  Add evalFileContinous + Write error in file

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,12 @@
 					"alt": "jsonnet.evalFileYaml",
 					"group": "navigation",
 					"when": "resourceLangId == jsonnet"
+				},
+        {
+					"command": "jsonnet.evalFileContinous",
+					"alt": "jsonnet.evalFileYaml",
+					"group": "navigation",
+					"when": "resourceLangId == jsonnet"
 				}
 			],
 			"editor/title/run": [
@@ -64,6 +70,12 @@
 			{
 				"command": "jsonnet.evalFile",
 				"title": "Jsonnet: Evaluate File",
+				"enablement": "resourceLangId == jsonnet",
+				"icon": "$(open-preview)"
+			},
+      {
+				"command": "jsonnet.evalFileContinous",
+				"title": "Jsonnet: Evaluate File Continious",
 				"enablement": "resourceLangId == jsonnet",
 				"icon": "$(open-preview)"
 			},


### PR DESCRIPTION
This PR aims to add:
- An `evalFileContinous` Command to continuously evaluation the current file in case of changes
- Writing the result of an  `evalFile` to an `error.json` to be able to read it properly