### PR TITLE
Add continuousEval via config + error to file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-jsonnet",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-jsonnet",
-			"version": "0.6.1",
+			"version": "0.7.0",
 			"license": "Apache License Version 2.0",
 			"dependencies": {
 				"@types/vscode": "^1.69.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Full code support (formatting, highlighting, navigation, debugging etc) for Jsonnet",
 	"license": "Apache License Version 2.0",
 	"publisher": "Grafana",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/grafana/vscode-jsonnet"
@@ -215,7 +215,7 @@
 					"default": false,
 					"description": "If enabled, the LSP will publish eval diagnostics. May produce false positives as the evaluator may not have the full evaluation context. Also, if you work with very large jsonnet projects, you may want to disable this for performance reasons"
 				},
-        "jsonnet.languageServer.continuousEval": {
+				"jsonnet.languageServer.continuousEval": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -215,6 +215,12 @@
 					"default": false,
 					"description": "If enabled, the LSP will publish eval diagnostics. May produce false positives as the evaluator may not have the full evaluation context. Also, if you work with very large jsonnet projects, you may want to disable this for performance reasons"
 				},
+        "jsonnet.languageServer.continuousEval": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to continuously evaluate the selected file"
+				},
 				"jsonnet.languageServer.lint": {
 					"scope": "resource",
 					"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,19 +109,19 @@ function evalFileFunc(yaml: boolean) {
     const tempFile = createTmpFile(yaml);
     const uri = Uri.file(tempFile);
 
-    if (!yaml){
+    if (!yaml) {
       fs.writeFileSync(tempFile, '{}');
     }
 
     if (workspace.getConfiguration('jsonnet').get('languageServer.continuousEval') === false) {
       evalAndDisplay(params, yaml, tempFile);
     }
-    else{
+    else {
 
       // Initial eval
       evalOnDisplay(params, yaml, tempFile);
 
-      let watcher = workspace.createFileSystemWatcher(currentFilePath);
+      const watcher = workspace.createFileSystemWatcher(currentFilePath);
 
       window.showTextDocument(uri, {
         preview: true,
@@ -129,8 +129,8 @@ function evalFileFunc(yaml: boolean) {
         preserveFocus: true,
       });
       watcher.onDidChange((e) => {
-          evalOnDisplay(params, yaml, tempFile);
-        }
+        evalOnDisplay(params, yaml, tempFile);
+      }
       );
     }
   };
@@ -207,7 +207,7 @@ function evalAndDisplay(params: ExecuteCommandParams, yaml: boolean, tempFile: s
       window.showErrorMessage(err.message);
       fs.writeFileSync(tempFile, err.message);
       const uri = Uri.file(tempFile);
-        window.showTextDocument(uri, {
+      window.showTextDocument(uri, {
         preview: true,
         viewColumn: ViewColumn.Beside,
       });


### PR DESCRIPTION
@julienduchesne  Here are the requested changes from #46 : 
- Errors on the new result window
- continuousEval can be set to enable/disable a continuous evaluation of the selected file it is on `true` per default
- This also works for yaml documents
- (Refactoring moved tempFile creation to an external function)

I will close #46 accordingly.