### PR TITLE
fix: treat importbin as keyword

### DIFF
--- a/language/jsonnet.tmLanguage.json
+++ b/language/jsonnet.tmLanguage.json
@@ -83,7 +83,7 @@
                     "name": "keyword.other.jsonnet"
                 },
                 {
-                    "match": "\\b(self|super|import|importstr|local|tailstrict)\\b",
+                    "match": "\\b(self|super|import|importstr|importbin|local|tailstrict)\\b",
                     "name": "keyword.other.jsonnet"
                 },
                 {


### PR DESCRIPTION
While using the extension, I noticed `importstr` is highlighted as a keyword, but `importbin` is not. Per https://jsonnet.org/ref/spec.html#lexing, `importbin` is also a reserved keyword.