### PR TITLE
Fix: keep using existing binary when GitHub release check fails

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -80,6 +80,15 @@ export async function install(
       latestVersion = latestVersion.substring(1);
     }
   } catch (e) {
+    // If we already have a binary on disk, prefer continuing with it rather than failing activation.
+    if (binPathExists) {
+      const warnMsg = `Failed to fetch latest release from ${releaseUrl}. Continuing with the current binary.`;
+      channel.appendLine(warnMsg);
+      channel.appendLine(e);
+      window.showWarningMessage(warnMsg);
+      return binPath;
+    }
+
     const msg = `Failed to fetch latest release from ${releaseUrl}`;
     channel.appendLine(msg);
     channel.appendLine(e);


### PR DESCRIPTION
## Background

When auto-update is enabled, the extension fetches `releases/latest` from GitHub. Behind NAT / shared IP environments, this request can hit GitHub’s unauthenticated rate limit. Previously, a failed release check could throw and prevent the language server from starting even if a valid binary already existed locally.

Resolve #44 

## Change

If fetching the latest release fails and the binary already exists at `binPath`, log a warning and continue using the existing binary instead of throwing.

## Why

Improves reliability in corporate/NAT networks and avoids “random” LSP unavailability caused by rate limiting.

## Notes

Behavior when the binary does not exist is unchanged (still errors if auto-update cannot fetch release info).